### PR TITLE
Replace base model to Llama4

### DIFF
--- a/libs/meta/langchain_meta/chat_models.py
+++ b/libs/meta/langchain_meta/chat_models.py
@@ -57,7 +57,7 @@ class ChatLlama(BaseChatOpenAI):  # type: ignore[override]
             from langchain_meta import ChatLlama
 
             llm = ChatLlama(
-                model="Llama-3.3-8B-Instruct",
+                model="Llama-4-Scout-17B-16E-Instruct-FP8",
                 temperature=0,
                 max_tokens=None,
                 timeout=None,
@@ -84,7 +84,7 @@ class ChatLlama(BaseChatOpenAI):  # type: ignore[override]
                 content="J'adore la programmation.",
                 response_metadata={
                     'token_usage': {'completion_tokens': 9, 'prompt_tokens': 32, 'total_tokens': 41},
-                    'model_name': 'Llama-3.3-8B-Instruct',
+                    'model_name': 'Llama-4-Scout-17B-16E-Instruct-FP8',
                     'system_fingerprint': None,
                     'finish_reason': 'stop',
                     'logprobs': None
@@ -108,7 +108,7 @@ class ChatLlama(BaseChatOpenAI):  # type: ignore[override]
             content=' programm' id='run-1bc996b5-293f-4114-96a1-e0f755c05eb9'
             content='ation' id='run-1bc996b5-293f-4114-96a1-e0f755c05eb9'
             content='.' id='run-1bc996b5-293f-4114-96a1-e0f755c05eb9'
-            content='' response_metadata={'finish_reason': 'stop', 'model_name': 'Llama-3.3-8B-Instruct'} id='run-1bc996b5-293f-4114-96a1-e0f755c05eb9'
+            content='' response_metadata={'finish_reason': 'stop', 'model_name': 'Llama-4-Scout-17B-16E-Instruct-FP8'} id='run-1bc996b5-293f-4114-96a1-e0f755c05eb9'
 
 
     Async:
@@ -128,7 +128,7 @@ class ChatLlama(BaseChatOpenAI):  # type: ignore[override]
                 content="J'adore la programmation.",
                 response_metadata={
                     'token_usage': {'completion_tokens': 9, 'prompt_tokens': 32, 'total_tokens': 41},
-                    'model_name': 'Llama-3.3-8B-Instruct',
+                    'model_name': 'Llama-4-Scout-17B-16E-Instruct-FP8',
                     'system_fingerprint': None,
                     'finish_reason': 'stop',
                     'logprobs': None
@@ -205,7 +205,7 @@ class ChatLlama(BaseChatOpenAI):  # type: ignore[override]
                     'prompt_tokens': 19,
                     'total_tokens': 23
                     },
-                'model_name': 'Llama-3.3-8B-Instruct',
+                'model_name': 'Llama-4-Scout-17B-16E-Instruct-FP8',
                 'system_fingerprint': None,
                 'finish_reason': 'stop',
                 'logprobs': None

--- a/libs/meta/pyproject.toml
+++ b/libs/meta/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "aiohttp<4,>=3.9.1",
 ]
 name = "langchain-meta"
-version = "0.0.1"
+version = "0.0.2"
 description = "An integration package connecting Llama and LangChain"
 readme = "README.md"
 
@@ -72,4 +72,3 @@ pytest = "^8.3.5"
 pytest-socket = "^0.7.0"
 pytest-asyncio = "^0.26.0"
 langchain-tests = "0.3.18"
-

--- a/libs/meta/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/meta/tests/integration_tests/test_chat_models_standard.py
@@ -27,7 +27,7 @@ class TestLlamaStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "Llama-3.3-8B-Instruct",
+            "model": "Llama-4-Scout-17B-16E-Instruct-FP8",
             "rate_limiter": rate_limiter,
             "stream_usage": True,
         }
@@ -36,7 +36,7 @@ class TestLlamaStandard(ChatModelIntegrationTests):
 def test_reasoning_content() -> None:
     """Test reasoning content."""
     chat_model = ChatLlama(
-        model="Llama-3.3-8B-Instruct",
+        model="Llama-4-Scout-17B-16E-Instruct-FP8",
         reasoning_effort="low",
     )
     response = chat_model.invoke([HumanMessage(content="What is 3^3?")])

--- a/libs/meta/tests/unit_tests/__snapshots__/test_chat_models_standard.ambr
+++ b/libs/meta/tests/unit_tests/__snapshots__/test_chat_models_standard.ambr
@@ -17,7 +17,7 @@
       }),
       'max_retries': 2,
       'max_tokens': 100,
-      'model_name': 'Llama-3.3-8B-Instruct',
+      'model_name': 'Llama-4-Scout-17B-16E-Instruct-FP8',
       'request_timeout': 60.0,
       'stop': list([
       ]),

--- a/libs/meta/tests/unit_tests/test_chat_models.py
+++ b/libs/meta/tests/unit_tests/test_chat_models.py
@@ -19,7 +19,7 @@ from langchain_meta import ChatLlama
 
 def test_initialization() -> None:
     """Test chat model initialization."""
-    ChatLlama(model="Llama-3.3-8B-Instruct")
+    ChatLlama(model="Llama-4-Scout-17B-16E-Instruct-FP8")
 
 
 def test_llama_model_param() -> None:
@@ -35,7 +35,7 @@ def test_chat_llama_invalid_streaming_params() -> None:
     """Test that streaming correctly invokes on_llm_new_token callback."""
     with pytest.raises(ValueError):
         ChatLlama(
-            model="Llama-3.3-8B-Instruct",
+            model="Llama-4-Scout-17B-16E-Instruct-FP8",
             max_tokens=10,
             streaming=True,
             temperature=0,
@@ -46,17 +46,21 @@ def test_chat_llama_invalid_streaming_params() -> None:
 def test_chat_llama_extra_kwargs() -> None:
     """Test extra kwargs to chat llama."""
     # Check that foo is saved in extra_kwargs.
-    llm = ChatLlama(model="Llama-3.3-8B-Instruct", foo=3, max_tokens=10)  # type: ignore[call-arg]
+    llm = ChatLlama(model="Llama-4-Scout-17B-16E-Instruct-FP8", foo=3, max_tokens=10)  # type: ignore[call-arg]
     assert llm.max_tokens == 10
     assert llm.model_kwargs == {"foo": 3}
 
     # Test that if extra_kwargs are provided, they are added to it.
-    llm = ChatLlama(model="Llama-3.3-8B-Instruct", foo=3, model_kwargs={"bar": 2})  # type: ignore[call-arg]
+    llm = ChatLlama(
+        model="Llama-4-Scout-17B-16E-Instruct-FP8", foo=3, model_kwargs={"bar": 2}
+    )  # type: ignore[call-arg]
     assert llm.model_kwargs == {"foo": 3, "bar": 2}
 
     # Test that if provided twice it errors
     with pytest.raises(ValueError):
-        ChatLlama(model="Llama-3.3-8B-Instruct", foo=3, model_kwargs={"foo": 2})  # type: ignore[call-arg]
+        ChatLlama(
+            model="Llama-4-Scout-17B-16E-Instruct-FP8", foo=3, model_kwargs={"foo": 2}
+        )  # type: ignore[call-arg]
 
 
 def test_function_dict_to_message_function_message() -> None:

--- a/libs/meta/tests/unit_tests/test_chat_models_standard.py
+++ b/libs/meta/tests/unit_tests/test_chat_models_standard.py
@@ -63,7 +63,7 @@ class TestLlamaStandard(ChatModelUnitTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "Llama-3.3-8B-Instruct"}
+        return {"model": "Llama-4-Scout-17B-16E-Instruct-FP8"}
 
     @property
     def init_from_env_params(self) -> tuple[dict, dict, dict]:
@@ -72,7 +72,7 @@ class TestLlamaStandard(ChatModelUnitTests):
                 "LLAMA_API_KEY": "api_key",
             },
             {
-                "model": "Llama-3.3-8B-Instruct",
+                "model": "Llama-4-Scout-17B-16E-Instruct-FP8",
             },
             {
                 "llama_api_key": "api_key",

--- a/libs/meta/tests/unit_tests/test_secrets.py
+++ b/libs/meta/tests/unit_tests/test_secrets.py
@@ -3,6 +3,6 @@ from langchain_meta import ChatLlama
 
 
 def test_chat_llama_secrets() -> None:
-    o = ChatLlama(model="Llama-3.3-8B-Instruct", llama_api_key="foo")  # type: ignore[call-arg]
+    o = ChatLlama(model="Llama-4-Scout-17B-16E-Instruct-FP8", llama_api_key="foo")  # type: ignore[call-arg]
     s = str(o)
     assert "foo" not in s


### PR DESCRIPTION
Upgrade the Llama model used across the codebase from `Llama-3.3-8B-Instruct` to `Llama-4-Scout-17B-16E-Instruct-FP8`.