### PR TITLE
Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -82,7 +82,9 @@ jobs:
       - build
     uses:
       ./.github/workflows/_test_release.yml
-    permissions: write-all
+    permissions:
+      contents: read
+      id-token: write
     with:
       working-directory: ${{ inputs.working-directory }}
       dangerous-nonmaster-release: ${{ inputs.dangerous-nonmaster-release }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   UV_NO_SYNC: "true"

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -13,6 +13,9 @@ on:
         default: false
         description: "Release from a non-master branch (danger!)"
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   UV_FROZEN: "true"

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: read` to 6 workflows that were missing permissions declarations (`_lint.yml`, `_test.yml`, `_compile_integration_test.yml`, `_integration_test.yml`, `_test_release.yml`, `check_diffs.yml`)
- Replaces overly broad `permissions: write-all` on the `test-pypi-publish` job in `_release.yml` with the minimum required `contents: read` and `id-token: write`

Addresses code scanning alerts for [actions/missing-workflow-permissions](https://github.com/langchain-ai/langchain-meta/security/code-scanning) (CWE-275). Restricts the default `GITHUB_TOKEN` scope following the principle of least privilege.

## Test plan
- [ ] CI passes on this PR (check_diffs workflow runs successfully)
- [ ] Verify release workflow still works on next release (test-pypi-publish job needs `id-token: write` for trusted publishing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)