### PR TITLE
chore(meta): deprecate chat models from llama api service

### DIFF
--- a/libs/meta/langchain_meta/chat_models.py
+++ b/libs/meta/langchain_meta/chat_models.py
@@ -5,6 +5,7 @@ import os
 from typing import Any, Literal, TypeVar, Union
 
 import openai
+from langchain_core._api import deprecated
 from langchain_core.language_models.chat_models import (
     LangSmithParams,
     LanguageModelInput,
@@ -22,6 +23,13 @@ _DictOrPydanticClass = Union[dict[str, Any], type[_BM], type]
 _DictOrPydantic = Union[dict, _BM]
 
 
+@deprecated(
+    since="0.5.0",
+    message=(
+        "The Meta Llama service was shut down on July 6, 2026. "
+        "ChatLlama will be removed in a future release."
+    ),
+)
 class ChatLlama(BaseChatOpenAI):  # type: ignore[override]
     r"""ChatLlama chat model.
 

--- a/libs/meta/langchain_meta/chat_models_v2_ported.py
+++ b/libs/meta/langchain_meta/chat_models_v2_ported.py
@@ -14,6 +14,7 @@ from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from operator import itemgetter
 from typing import Any, ClassVar, Literal, Union
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -90,7 +91,13 @@ class RaisingPydanticToolsParser(PydanticToolsParser):
         raise err
 
 
-# STEEXZDdafsdfgasdfg
+@deprecated(
+    since="0.5.0",
+    message=(
+        "The Meta Llama service was shut down on July 6, 2026. "
+        "ChatMetaLlama will be removed in a future release."
+    ),
+)
 class ChatMetaLlama(SyncChatMetaLlamaMixin, AsyncChatMetaLlamaMixin, BaseChatModel):
     """LangChain ChatModel wrapper for the native Meta Llama API using llama-api-client.
 

--- a/libs/meta/langchain_meta/unified_chat.py
+++ b/libs/meta/langchain_meta/unified_chat.py
@@ -5,6 +5,8 @@ Supports both OpenAI-based and native Llama API backends.
 
 from typing import Any, Union
 
+from langchain_core._api import deprecated
+
 from .chat_models import ChatLlama as ChatLlamaOpenAI
 from .chat_models_v2_ported import ChatMetaLlama as ChatLlamaNative
 
@@ -38,6 +40,14 @@ class ChatLlama:
         )
     """
 
+    @deprecated(
+        since="0.5.0",
+        name="ChatLlama",
+        message=(
+            "The Meta Llama service was shut down on July 6, 2026. "
+            "ChatLlama will be removed in a future release."
+        ),
+    )
     def __new__(  # type: ignore[misc]
         cls, use_native_client: bool = False, **kwargs: Any
     ) -> Union[ChatLlamaOpenAI, ChatLlamaNative]:


### PR DESCRIPTION
The Llama API Public Preview was retired on July 6, 2026.