### PR TITLE
chore(infra): skip integration tests on release

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -169,6 +169,8 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Run integration tests
+        # TODO: set up CI
+        if: false
         env:
           LLAMA_API_KEY: ${{ secrets.LLAMA_API_KEY }}
         run: |


### PR DESCRIPTION
Until secrets are set up in CI.